### PR TITLE
20171014_課題

### DIFF
--- a/20171014/20171014_shooting_game/Assets/_Complete-Game/Scripts/Managers/EnemyManager.cs
+++ b/20171014/20171014_shooting_game/Assets/_Complete-Game/Scripts/Managers/EnemyManager.cs
@@ -6,6 +6,7 @@ namespace CompleteProject
     {
         public PlayerHealth playerHealth;       // Reference to the player's heatlh.
         public GameObject enemy;                // The enemy prefab to be spawned.
+        public GameObject enemyInstance;
         public float spawnTime = 3f;            // How long between each spawn.
         public Transform[] spawnPoints;         // An array of the spawn points this enemy can spawn from.
 
@@ -33,6 +34,18 @@ namespace CompleteProject
 
             // Create an instance of the enemy prefab at the randomly selected spawn point's position and rotation.
             enemyInstance = Instantiate (enemy, spawnPoints[spawnPointIndex].position, spawnPoints[spawnPointIndex].rotation);
+
+            enemyInstance.GetComponent<UnityEngine.AI.NavMeshAgent>().speed *= Mathf.Pow(1.05f,speedCount);
+        }
+
+        public void UpdateSpown() {
+            spawnTime *= 0.9f;
+            CancelInvoke("Spawn");
+            InvokeRepeating ("Spawn", spawnTime, spawnTime);
+        }
+
+        public void UpdateSpeed() {
+            speedCount++;
         }
 
     }

--- a/20171014/20171014_shooting_game/Assets/_Complete-Game/Scripts/Managers/EnemyManager.cs
+++ b/20171014/20171014_shooting_game/Assets/_Complete-Game/Scripts/Managers/EnemyManager.cs
@@ -19,6 +19,9 @@ namespace CompleteProject
             InvokeRepeating ("Spawn", spawnTime, spawnTime);
         }
 
+        void Update() {
+            Debug.Log("[score] " + ScoreManager.score);
+        }
 
         void Spawn ()
         {

--- a/20171014/20171014_shooting_game/Assets/_Complete-Game/Scripts/Managers/ScoreManager.cs
+++ b/20171014/20171014_shooting_game/Assets/_Complete-Game/Scripts/Managers/ScoreManager.cs
@@ -8,6 +8,11 @@ namespace CompleteProject
     public class ScoreManager : MonoBehaviour
     {
         public static int score;        // The player's score.
+        private EnemyManager[] scripts;
+        private const int INTERVAL_UPDATE_COUNT = 100;
+        private const int INTERVAL_UPDATE_SPEED = 200;
+        private int nextTargetScore1 = INTERVAL_UPDATE_COUNT;
+        private int nextTargetScore2 = INTERVAL_UPDATE_SPEED;
 
         Text text;                      // Reference to the Text component.
 
@@ -19,6 +24,8 @@ namespace CompleteProject
 
             // Reset the score.
             score = 0;
+
+            scripts = GameObject.Find("EnemyManager").GetComponents<EnemyManager>();
         }
 
 
@@ -46,6 +53,23 @@ namespace CompleteProject
             {
                 // 白
                 text.color = Color.white;
+            }
+
+            // 100ptごとにspown率を更新
+            if(score >= nextTargetScore1){
+                nextTargetScore1 += INTERVAL_UPDATE_COUNT;
+                foreach (var script in scripts)
+                {
+                    script.UpdateSpown();
+                }
+            }
+            // 200ptごとにスピードアップ
+            if(score >= nextTargetScore2){
+                nextTargetScore2 += INTERVAL_UPDATE_SPEED;
+                foreach (var script in scripts)
+                {
+                    script.UpdateSpeed();
+                }
             }
 
         }


### PR DESCRIPTION
## 課題３
【Scoreに応じてSpawn頻度を変化させよう】
現状の実装内容から１００点Getするごとにスポーン率を１０％増加させる
(オプション)生成するモンスターによってスポーン率の増減を変化させる

## 課題４
２００点ごとにNavMeshの速度を上昇させよう
NavMeshのAgent速度を２００点ごとに５％上昇させよう。

## コメント
今後もスコアごとにイベントが追加されていくことを想定して、
トリガーとなる定数はScoreManagerの中に書くようにした。
「何ポイントのときに何をするのか」をScoreManagerを見るだけでわかるようにする。